### PR TITLE
Window position when dragged down to minimize

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -35,6 +35,7 @@ class View {
   void tile_right();
   void tile_left();
   void toggle_maximized();
+  bool windowed() const;
 
   void focus_view(wlr_surface *surface);
   bool view_at(double lx, double ly, wlr_surface **surface, double *sx, double *sy);
@@ -48,7 +49,7 @@ class View {
 
   virtual void maximize() = 0;
   virtual void tile(int edges) = 0;
-  virtual void windowify(bool restore_position) = 0;
+  virtual void window(bool restore_position) = 0;
 
   virtual void resize(int width, int height) = 0;
 

--- a/include/views/xdg_view.h
+++ b/include/views/xdg_view.h
@@ -13,7 +13,7 @@ class XdgView : public View {
 
   void maximize();
   void tile(int edges);
-  void windowify(bool restore_position);
+  void window(bool restore_position);
 
   void resize(int width, int height);
 

--- a/include/views/xwayland_view.h
+++ b/include/views/xwayland_view.h
@@ -13,7 +13,7 @@ class XWaylandView : public View {
 
   void maximize();
   void tile(int edges);
-  void windowify(bool restore_position);
+  void window(bool restore_position);
 
   void resize(int width, int height);
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -254,7 +254,7 @@ static void xdg_surface_commit_notify(wl_listener *listener, void *data) {
 
 static void xdg_toplevel_request_move_notify(wl_listener *listener, void *data) {
   View *view = wl_container_of(listener, view, request_move);
-  view->windowify(false);
+  view->window(false);
   view->begin_interactive(WM_CURSOR_MOVE, 0);
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -76,10 +76,11 @@ bool View::windowed() const {
 }
 
 void View::toggle_maximized() {
-  if (state != WM_WINDOW_STATE_WINDOW) {
-    window(true);
-  } else {
+  bool is_windowed = windowed();
+  if (is_windowed) {
     maximize();
+  } else {
+    window(true);
   }
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -70,9 +70,14 @@ void View::focus_view(wlr_surface *surface) {
   notify_keyboard_enter();
 }
 
+bool View::windowed() const {
+  bool windowed = state == WM_WINDOW_STATE_WINDOW;
+  return windowed;
+}
+
 void View::toggle_maximized() {
   if (state != WM_WINDOW_STATE_WINDOW) {
-    windowify(true);
+    window(true);
   } else {
     maximize();
   }

--- a/src/views/xwayland_view.cpp
+++ b/src/views/xwayland_view.cpp
@@ -106,7 +106,7 @@ void XWaylandView::maximize() {
   state = WM_WINDOW_STATE_MAXIMIZED;
 }
 
-void XWaylandView::windowify(bool restore_position) {
+void XWaylandView::window(bool restore_position) {
   if (state == WM_WINDOW_STATE_WINDOW) {
     return;
   }


### PR DESCRIPTION
When a window is dragged down and transitions from maximized or tiled to window then focus the window titlebar around the cursor.